### PR TITLE
feat: ops to auto disable Zen and Narrow when exits Focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ FOCUS.nvim comes with the following defaults:
     options = {},
   },
   auto_zen = false, -- auto enable zen mode when entering focus mode
+  auto_disable_zen = false, -- auto disable zen mode when exiting focus mode
+  auto_disable_narrow = false, -- auto disable zen mode when exiting focus mode
   -- by default, the options below are disabled for zen mode
   zen = {
     opts = {

--- a/doc/focus.txt
+++ b/doc/focus.txt
@@ -115,6 +115,8 @@ FOCUS.nvim comes with the following defaults:
         options = {},
       },
       auto_zen = false, -- auto enable zen mode when entering focus mode
+      auto_disable_zen = false, -- auto disable zen mode when exiting focus mode
+      auto_disable_narrow = false, -- auto disable zen mode when exiting focus mode
       -- by default, the options below are disabled for zen mode
       zen = {
         opts = {

--- a/lua/focus/config.lua
+++ b/lua/focus/config.lua
@@ -16,6 +16,8 @@ local M = {}
 ---@field zindex? number zindex of the focus, should be less than 50
 ---@field window? focus.WindowOpts options for focus window
 ---@field auto_zen? boolean if true, auto enable zen mode when entering focus mode
+---@field auto_disable_zen? boolean if true, auto disable zen mode when exiting focus mode
+---@field auto_disable_narrow? boolean if true, auto disable zen mode when exiting focus mode
 ---@field zen? focus.ZenOpts options for zen mode
 ---@field plugins? table plugins to disable/enable in focus mode
 ---@field on_open? function callback when entering focus window
@@ -34,6 +36,8 @@ local defaults = {
     options = {},
   },
   auto_zen = false,
+  auto_disable_zen = false,
+  auto_disable_narrow = false,
   -- by default, the options below are disabled for zen mode
   zen = {
     opts = {

--- a/lua/focus/views/focus.lua
+++ b/lua/focus/views/focus.lua
@@ -41,8 +41,6 @@ function M.plugins_on_close()
 end
 
 --- Closes focus mode and restores original state.
---- NOTE: we are also disabling zen and narrow modes when exiting focus mode but maybe
---- that decision should be left to the user---i.e. must explicitly exit narrow/zen mode
 function M.close()
   ---@diagnostic disable-next-line: param-type-mismatch
   pcall(vim.cmd, "autocmd! Focus")
@@ -72,12 +70,18 @@ function M.close()
   if M.opts then
     M.plugins_on_close()
     M.opts.on_close()
+
+    if M.opts.auto_disable_zen then
+      zen.deactivate()
+    end
+    if M.opts.auto_disable_narrow then
+      narrow.unfocus()
+    end
+
     M.opts = nil
     if M.parent and vim.api.nvim_win_is_valid(M.parent) then
       vim.api.nvim_set_current_win(M.parent)
     end
-    zen.deactivate()
-    narrow.unfocus()
   end
 end
 


### PR DESCRIPTION
Add 2 options `auto_disable_zen` and `auto_disable_narrow` to disable them automatically after exiting `Focus`